### PR TITLE
Screensaver and light control

### DIFF
--- a/OLEDTimerWizard/button.ino
+++ b/OLEDTimerWizard/button.ino
@@ -118,7 +118,15 @@ void buttonAction() {
   if ( (stateIdx == SJON) && (encoderButton.clicks == 1) ) {
           offRelay();
         }
-  
+
+
+  #ifdef screensaver
+  // PAUSE -> OFF
+    else if ( (stateIdx == PAUSE) && (encoderButton.clicks == 1) ) {
+            offPause();
+        }
+  #endif
+
   // OFF -> ON
   else if ( (stateIdx == SJOFF) && (encoderButton.clicks == 1) ) {
           onRelay();
@@ -129,13 +137,27 @@ void buttonAction() {
           doseIdx = quickButtonPortion[QB1];
           onRelay();
         }
+        
+  #ifdef screensaver 
+  // quickbutton 1 pressed when paused
+  else if ( ( stateIdx == PAUSE) && (quickButton1.clicks == 1) ) {
+          offPause();
+        }
+  #endif
   
   // quickbutton 2 pressed
   else if ( (stateIdx == SJOFF) && (quickButton2.clicks == 1) ) {
           doseIdx = quickButtonPortion[QB2];
           onRelay();
         }
-  
+
+  #ifdef screensaver
+    // quickbutton 2 pressed when paused
+    else if ( ( stateIdx == PAUSE) && (quickButton2.clicks == 1) ) {
+            offPause();     
+          }
+  #endif   
+
   // OFF -> SET
   else if ( (stateIdx == SJOFF) && (doseIdx != DOSEM)&& (encoderButton.clicks == -1) ) {
           stateIdx = SJSET;
@@ -212,6 +234,9 @@ void do_dosecalc() {
 void onRelay() {
   stateIdx = SJON;
   currentTime = doseTime[doseIdx];
+   #ifdef LIGHT
+    led.fade(MAX_LIGHT, 1000);
+  #endif
 }
 
 /* turn relay off */

--- a/OLEDTimerWizard/display.ino
+++ b/OLEDTimerWizard/display.ino
@@ -104,13 +104,24 @@ void draw() {
   byte boxWidth = 0;
   if ( stateIdx == SJSET ) boxWidth = display_width;
   if ( stateIdx == SJOFF ) boxWidth = 0;
-  if ( stateIdx == SJON ) boxWidth = display_width * ( 1 - float(currentTime)/float(doseTime[doseIdx]) );
-  if ( stateIdx != WIZARD ) { 
+  if ( stateIdx == SJON ) {
     u8g.drawFrame(0,0,display_width,10);
+    boxWidth = display_width * ( 1 - float(currentTime)/float(doseTime[doseIdx]) );
+    }
+  if ( stateIdx != WIZARD || stateIdx != PAUSE ) { 
+    // u8g.drawFrame(0,0,display_width,10);
     u8g.drawBox(0,0,boxWidth,10);
   }
   
   switch (stateIdx) {
+
+  #ifdef screensaver
+    case PAUSE:
+    //  u8g.setFont(u8g_font_fub11); 
+    //  u8g.setPrintPos(40, 45);
+    //  u8g.print("Pause");
+        break;
+  #endif
   
   case SJSET:
     if (doseIdx != DOSEM) {

--- a/OLEDTimerWizard/encoder.ino
+++ b/OLEDTimerWizard/encoder.ino
@@ -33,7 +33,12 @@ void encoderAction()
          chooser(0,2);
         break;
         }
-   
+        #ifdef screensaver
+          case PAUSE:       // Exit screensaver and return to normal operation mode
+           offPause();
+          break;
+        #endif
+        
         case SJOFF:       // normal operation mode
           chooser(1,0);
         break;
@@ -65,10 +70,19 @@ void encoderAction()
 void integerInput(){                // input integer for time and weight
   doseTime[doseIdx] += (encoderVal > 0) ? 1 : -1;
   if (doseTime[doseIdx] <= 0) doseTime[doseIdx]=0;
+ 
+  #ifdef screensaver
+    previousMillis = millis();
+  #endif
 }
 
 void chooser(byte max, byte min){   // input integer from max to min e.g. YES/NO, number of doses, QB-setup...
   int ADOSES; 
+  
+  #ifdef screensaver
+    previousMillis = millis();
+  #endif 
+  
   if ( setupStateIdx == INIT ) {
     ADOSES = totalPortions-1; 
   } else {


### PR DESCRIPTION
 changelog v03/03/16
- added screensaver. Allows you to enable screensaver after a defined amount of seconds.
- added light control. Allows you to add an LED to pin 10. Light will fade up and down according to defined values. Will fade down when screensaver is activated.
- timer indicator, frame will only be drawn when actually grinding.
  LED-fade library is needed and can be found here: https://github.com/jgillick/arduino-LEDFader
